### PR TITLE
always use ID to skip btcpp warning anw

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -245,33 +245,31 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // Reset any existing Groot2 monitoring
   bt_->resetGrootMonitor();
 
-  bool is_bt_id = false;
-  if ((file_or_id.length() < 4) ||
-    file_or_id.substr(file_or_id.length() - 4) != ".xml")
-  {
-    is_bt_id = true;
-  }
-
+  std::string possible_bt_id = "";
   std::unordered_set<std::string> used_bt_id;
   for (const auto & directory : search_directories_) {
     try {
       for (const auto & entry : fs::directory_iterator(directory)) {
         if (entry.path().extension() == ".xml") {
-          auto current_bt_id = bt_->extractBehaviorTreeID(entry.path().string());
+          const auto path_str = entry.path().string();
+          auto current_bt_id = bt_->extractBehaviorTreeID(path_str);
           if (current_bt_id.empty()) {
             RCLCPP_ERROR(logger_, "Skipping BT file %s (missing ID)",
-              entry.path().string().c_str());
+              path_str.c_str());
             continue;
           }
-          auto [it, inserted] = used_bt_id.insert(current_bt_id);
+          if (possible_bt_id.empty() && path_str == file_or_id) {
+            possible_bt_id = current_bt_id;
+          }
+          auto inserted = used_bt_id.insert(current_bt_id).second;
           if (!inserted) {
             RCLCPP_WARN(
               logger_,
               "Warning: Duplicate BT IDs found. Make sure to have all BT IDs unique! "
               "ID: %s File: %s",
-              current_bt_id.c_str(), entry.path().string().c_str());
+              current_bt_id.c_str(), path_str.c_str());
           }
-          bt_->registerTreeFromFile(entry.path().string());
+          bt_->registerTreeFromFile(path_str);
         }
       }
     } catch (const std::exception & e) {
@@ -282,11 +280,9 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   }
   // Try to load the main BT tree (by ID)
   try {
-    if(!is_bt_id) {
-      tree_ = bt_->createTreeFromFile(file_or_id, blackboard_);
-    } else {
-      tree_ = bt_->createTree(file_or_id, blackboard_);
-    }
+    const auto & tree_id = possible_bt_id.empty() ? file_or_id : possible_bt_id;
+    tree_ = bt_->createTree(tree_id, blackboard_);
+    RCLCPP_INFO(logger_, "Created BT from %s", file_or_id.c_str());
 
     for (auto & subtree : tree_.subtrees) {
       auto & blackboard = subtree->blackboard;

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -110,32 +110,31 @@ public:
     const std::vector<std::string> & search_directories)
   {
     namespace fs = std::filesystem;
-    bool is_bt_id = false;
-    if ((file_or_id.length() < 4) ||
-      file_or_id.substr(file_or_id.length() - 4) != ".xml")
-    {
-      is_bt_id = true;
-    }
     // Register all XML behavior subtrees in the directories
+    std::string possible_bt_id = "";
     std::unordered_set<std::string> used_bt_id;
     for (const auto & directory : search_directories) {
       try {
         for (const auto & entry : fs::directory_iterator(directory)) {
           if (entry.path().extension() == ".xml") {
-            auto current_bt_id = bt_engine_->extractBehaviorTreeID(entry.path().string());
+            const auto path_str = entry.path().string();
+            auto current_bt_id = bt_engine_->extractBehaviorTreeID(path_str);
             if (current_bt_id.empty()) {
               std::cerr << "[behavior_tree_handler]: Skipping BT file "
-                        << entry.path().string() << " (missing ID)\n";
+                        << path_str << " (missing ID)\n";
               continue;
             }
-            auto [it, inserted] = used_bt_id.insert(current_bt_id);
+            if (possible_bt_id.empty() && path_str == file_or_id) {
+              possible_bt_id = current_bt_id;
+            }
+            auto inserted = used_bt_id.insert(current_bt_id).second;
             if (!inserted) {
               std::cout << "[behavior_tree_handler]: Warning: Duplicate BT IDs found. "
                 "Make sure to have all BT IDs unique! "
                         << "ID: " << current_bt_id
-                        << " File: " << entry.path().string() << "\n";
+                        << " File: " << path_str << "\n";
             }
-            factory_.registerBehaviorTreeFromFile(entry.path().string());
+            factory_.registerBehaviorTreeFromFile(path_str);
           }
         }
       } catch (const std::exception & e) {
@@ -150,13 +149,8 @@ public:
 
     // Build the tree from the ID (resolved from <root> or <BehaviorTree ID>)
     try {
-      if(!is_bt_id) {
-        tree = factory_.createTreeFromFile(file_or_id, blackboard);
-        RCLCPP_WARN(node_->get_logger(),
-          "Loading BT using file path. This is deprecated. Please use the BT ID instead.");
-      } else {
-        tree = factory_.createTree(file_or_id, blackboard);
-      }
+      const auto & tree_id = possible_bt_id.empty() ? file_or_id : possible_bt_id;
+      tree = factory_.createTree(tree_id, blackboard);
     } catch (BT::RuntimeError & exp) {
       RCLCPP_ERROR(node_->get_logger(),
         "Failed to create BT %s: %s", file_or_id.c_str(), exp.what());


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
