### PR TITLE
fix the loadbehaviortree impl and its test

### DIFF
--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -22,6 +22,7 @@
 #include <memory>
 #include <set>
 #include <unordered_set>
+#include <unordered_map>
 #include <string>
 #include <vector>
 
@@ -246,33 +247,30 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   // Reset any existing Groot2 monitoring
   bt_->resetGrootMonitor();
 
-  bool is_bt_id = false;
-  if ((file_or_id.length() < 4) ||
-    file_or_id.substr(file_or_id.length() - 4) != ".xml")
-  {
-    is_bt_id = true;
-  }
+  const std::string kXmlExtension = ".xml";
+  const bool is_bt_id = (file_or_id.length() < kXmlExtension.size()) ||
+    (file_or_id.compare(file_or_id.length() - kXmlExtension.size(),
+                             kXmlExtension.size(), kXmlExtension) != 0);
 
-  std::unordered_set<std::string> used_bt_id;
+  std::unordered_map<std::string, std::string> id_to_file;
+  std::unordered_set<std::string> duplicate_ids;
   for (const auto & directory : search_directories_) {
     try {
       for (const auto & entry : fs::directory_iterator(directory)) {
-        if (entry.path().extension() == ".xml") {
-          auto current_bt_id = bt_->extractBehaviorTreeID(entry.path().string());
-          if (current_bt_id.empty()) {
-            RCLCPP_ERROR(logger_, "Skipping BT file %s (missing ID)",
-              entry.path().string().c_str());
-            continue;
-          }
-          auto [it, inserted] = used_bt_id.insert(current_bt_id);
-          if (!inserted) {
-            RCLCPP_WARN(
-              logger_,
-              "Warning: Duplicate BT IDs found. Make sure to have all BT IDs unique! "
-              "ID: %s File: %s",
-              current_bt_id.c_str(), entry.path().string().c_str());
-          }
-          bt_->registerTreeFromFile(entry.path().string());
+        if (entry.path().extension() != ".xml") {continue;}
+
+        auto id = bt_->extractBehaviorTreeID(entry.path().string());
+        if (id.empty()) {
+          RCLCPP_ERROR(logger_, "Skipping BT file %s (missing ID)", entry.path().c_str());
+          continue;
+        }
+
+        if (id_to_file.count(id)) {
+          duplicate_ids.insert(id);
+          RCLCPP_WARN(logger_, "Duplicate BT ID detected: %s in files [%s, %s]", id.c_str(),
+              id_to_file[id].c_str(), entry.path().c_str());
+        } else {
+          id_to_file[id] = entry.path().string();
         }
       }
     } catch (const std::exception & e) {
@@ -281,12 +279,53 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
       return false;
     }
   }
-  // Try to load the main BT tree (by ID)
+  std::string main_file;
+  std::string main_id;
+
   try {
-    if(!is_bt_id) {
-      tree_ = bt_->createTreeFromFile(file_or_id, blackboard_);
+    if (!is_bt_id) {
+      main_file = file_or_id;
+      main_id = bt_->extractBehaviorTreeID(main_file);
+
+      if (main_id.empty()) {
+        RCLCPP_ERROR(logger_, "Failed to extract ID from %s", main_file.c_str());
+        return false;
+      }
+
+      // Register all trees, skipping duplicates that conflict with main tree
+      for (const auto & [id, path] : id_to_file) {
+        if (id == main_id && path != main_file) {
+          RCLCPP_WARN(
+              logger_, "Skipping conflicting BT file %s (duplicate ID %s)", path.c_str(),
+              id.c_str());
+          continue;
+        }
+        RCLCPP_INFO(logger_, "Registering Tree from File: %s", path.c_str());
+        bt_->registerTreeFromFile(path);
+      }
+
+      RCLCPP_INFO(logger_, "Registering main BT file explicitly: %s", main_file.c_str());
+      bt_->registerTreeFromFile(main_file);
+
+      tree_ = bt_->createTree(main_id, blackboard_);
+      RCLCPP_INFO(logger_, "Created BT from ID: %s", main_id.c_str());
+
     } else {
+      if (duplicate_ids.count(file_or_id)) {
+        RCLCPP_ERROR(logger_,
+            "Conflicting BT ID '%s' found in multiple files. Loading may be ambiguous. Concider "
+            "using unique IDs for each BT file.",
+            file_or_id.c_str());
+      }
+
+      for (const auto & [id, path] : id_to_file) {
+        if (path.empty()) {continue;}
+        RCLCPP_INFO(logger_, "Registering Tree from File: %s", path.c_str());
+        bt_->registerTreeFromFile(path);
+      }
+
       tree_ = bt_->createTree(file_or_id, blackboard_);
+      RCLCPP_INFO(logger_, "Creating tree from ID: %s", file_or_id.c_str());
     }
 
     for (auto & subtree : tree_.subtrees) {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -262,7 +262,6 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     };
 
   std::set<std::string> registered_ids;
-  std::vector<std::pair<std::string, std::string>> files_to_register;
 
   if (!is_bt_id) {
     // file_or_id is a filename: register it first
@@ -272,7 +271,8 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
       RCLCPP_ERROR(logger_, "Failed to extract ID from %s", main_file.c_str());
       return false;
     }
-    files_to_register.emplace_back(main_id, main_file);
+    RCLCPP_INFO(logger_, "Registering Tree from File: %s", main_file.c_str());
+    bt_->registerTreeFromFile(main_file);
     registered_ids.insert(main_id);
 
     // Register all other trees, skipping conflicts with main_id
@@ -290,15 +290,10 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
               entry.path().c_str(), id.c_str());
           continue;
         }
-        files_to_register.emplace_back(id, entry.path().string());
+        RCLCPP_INFO(logger_, "Registering Tree from File: %s", entry.path().string().c_str());
+        bt_->registerTreeFromFile(entry.path().string());
         registered_ids.insert(id);
       }
-    }
-
-    // Register all files
-    for (const auto & [id, path] : files_to_register) {
-      RCLCPP_INFO(logger_, "Registering Tree from File: %s", path.c_str());
-      bt_->registerTreeFromFile(path);
     }
 
     try {
@@ -316,7 +311,8 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
       RCLCPP_ERROR(logger_, "Could not find file for BT ID: %s", file_or_id.c_str());
       return false;
     }
-    files_to_register.emplace_back(file_or_id, main_file);
+    RCLCPP_INFO(logger_, "Registering Tree from File: %s", main_file.c_str());
+    bt_->registerTreeFromFile(main_file);
     registered_ids.insert(file_or_id);
 
     // Register all other trees, skipping conflicts
@@ -334,15 +330,10 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
               entry.path().c_str(), id.c_str());
           continue;
         }
-        files_to_register.emplace_back(id, entry.path().string());
+        RCLCPP_INFO(logger_, "Registering Tree from File: %s", entry.path().string().c_str());
+        bt_->registerTreeFromFile(entry.path().string());
         registered_ids.insert(id);
       }
-    }
-
-    // Register all files
-    for (const auto & [id, path] : files_to_register) {
-      RCLCPP_INFO(logger_, "Registering Tree from File: %s", path.c_str());
-      bt_->registerTreeFromFile(path);
     }
 
     try {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -20,7 +20,6 @@
 #include <fstream>
 #include <limits>
 #include <memory>
-#include <unordered_set>
 #include <set>
 #include <utility>
 #include <string>

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -307,7 +307,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     // and prioritized, even if other files in the directory have duplicate IDs.
     // The lambda then skips this main file to avoid
     // re-registering it or logging a duplicate warning.
-    // In contrast, when an ID is specified, it's unkown which file is "main"
+    // In contrast, when an ID is specified, it's unknown which file is "main"
     // so all files are registered and conflicts are handled in the lambda.
       register_all_bt_files(main_file);
     } else {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -292,7 +292,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
         RCLCPP_ERROR(logger_, "Failed to extract ID from %s", main_file.c_str());
         return false;
       }
-      RCLCPP_INFO(logger_, "Registering Tree from File: %s", main_file.c_str());
+      RCLCPP_DEBUG(logger_, "Registering Tree from File: %s", main_file.c_str());
       bt_->registerTreeFromFile(main_file);
       registered_ids.insert(main_id);
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -276,7 +276,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
             continue;
           }
 
-          RCLCPP_INFO(logger_, "Registering Tree from File: %s", entry.path().string().c_str());
+          RCLCPP_DEBUG(logger_, "Registering Tree from File: %s", entry.path().string().c_str());
           bt_->registerTreeFromFile(entry.path().string());
           registered_ids.insert(id);
         }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -256,41 +256,36 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
   std::set<std::string> registered_ids;
   std::string main_id;
   auto register_all_bt_files = [&](const std::string & skip_file = "") {
-      try {
-        for (const auto & directory : search_directories_) {
-          for (const auto & entry : fs::directory_iterator(directory)) {
-            if (entry.path().extension() != ".xml") {
-              continue;
-            }
-            if (!skip_file.empty() && entry.path().string() == skip_file) {
-              continue;
-            }
-
-            auto id = bt_->extractBehaviorTreeID(entry.path().string());
-            if (id.empty()) {
-              RCLCPP_ERROR(logger_, "Skipping BT file %s (missing ID)", entry.path().c_str());
-              continue;
-            }
-            if (registered_ids.count(id)) {
-              RCLCPP_WARN(logger_, "Skipping conflicting BT file %s (duplicate ID %s)",
-              entry.path().c_str(), id.c_str());
-              continue;
-            }
-
-            RCLCPP_INFO(logger_, "Registering Tree from File: %s", entry.path().string().c_str());
-            bt_->registerTreeFromFile(entry.path().string());
-            registered_ids.insert(id);
+      for (const auto & directory : search_directories_) {
+        for (const auto & entry : fs::directory_iterator(directory)) {
+          if (entry.path().extension() != ".xml") {
+            continue;
           }
+          if (!skip_file.empty() && entry.path().string() == skip_file) {
+            continue;
+          }
+
+          auto id = bt_->extractBehaviorTreeID(entry.path().string());
+          if (id.empty()) {
+            RCLCPP_ERROR(logger_, "Skipping BT file %s (missing ID)", entry.path().c_str());
+            continue;
+          }
+          if (registered_ids.count(id)) {
+            RCLCPP_WARN(logger_, "Skipping conflicting BT file %s (duplicate ID %s)",
+        entry.path().c_str(), id.c_str());
+            continue;
+          }
+
+          RCLCPP_INFO(logger_, "Registering Tree from File: %s", entry.path().string().c_str());
+          bt_->registerTreeFromFile(entry.path().string());
+          registered_ids.insert(id);
         }
-      } catch (const std::exception & e) {
-        setInternalError(ActionT::Result::FAILED_TO_LOAD_BEHAVIOR_TREE,
-      "Exception reading behavior tree directory: " + std::string(e.what()));
       }
     };
 
   try {
     if (!is_bt_id) {
-    // file_or_id is a filename: register it first
+      // file_or_id is a filename: register it first
       std::string main_file = file_or_id;
       main_id = bt_->extractBehaviorTreeID(main_file);
       if (main_id.empty()) {
@@ -301,17 +296,17 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
       bt_->registerTreeFromFile(main_file);
       registered_ids.insert(main_id);
 
-    // When a filename is specified, it must be register first
-    // and treat it as the "main" tree to execute.
-    // This ensures the requested tree is always available
-    // and prioritized, even if other files in the directory have duplicate IDs.
-    // The lambda then skips this main file to avoid
-    // re-registering it or logging a duplicate warning.
-    // In contrast, when an ID is specified, it's unknown which file is "main"
-    // so all files are registered and conflicts are handled in the lambda.
+      // When a filename is specified, it must be register first
+      // and treat it as the "main" tree to execute.
+      // This ensures the requested tree is always available
+      // and prioritized, even if other files in the directory have duplicate IDs.
+      // The lambda then skips this main file to avoid
+      // re-registering it or logging a duplicate warning.
+      // In contrast, when an ID is specified, it's unknown which file is "main"
+      // so all files are registered and conflicts are handled in the lambda.
       register_all_bt_files(main_file);
     } else {
-    // file_or_id is an ID: register all files, skipping conflicts
+      // file_or_id is an ID: register all files, skipping conflicts
       main_id = file_or_id;
       register_all_bt_files();
     }

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -310,16 +310,6 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
     return false;
   }
 
-  // Set blackboard variables for all subtrees
-  for (auto & subtree : tree_.subtrees) {
-    auto & blackboard = subtree->blackboard;
-    blackboard->set("node", client_node_);
-    blackboard->set<std::chrono::milliseconds>("server_timeout", default_server_timeout_);
-    blackboard->set<std::chrono::milliseconds>("bt_loop_duration", bt_loop_duration_);
-    blackboard->set<std::chrono::milliseconds>(
-        "wait_for_service_timeout", wait_for_service_timeout_);
-  }
-
   topic_logger_ = std::make_unique<RosTopicLogger>(client_node_, tree_);
   current_bt_file_or_id_ = file_or_id;
 

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -255,7 +255,6 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
 
   std::set<std::string> registered_ids;
   std::string main_id;
-
   auto register_all_bt_files = [&](const std::string & skip_file = "") {
       try {
         for (const auto & directory : search_directories_) {

--- a/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
+++ b/nav2_behavior_tree/include/nav2_behavior_tree/bt_action_server_impl.hpp
@@ -272,7 +272,7 @@ bool BtActionServer<ActionT, NodeT>::loadBehaviorTree(const std::string & bt_xml
           }
           if (registered_ids.count(id)) {
             RCLCPP_WARN(logger_, "Skipping conflicting BT file %s (duplicate ID %s)",
-        entry.path().c_str(), id.c_str());
+              entry.path().c_str(), id.c_str());
             continue;
           }
 

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -176,15 +176,6 @@ public:
       return false;
     }
 
-    for (auto & subtree : tree.subtrees) {
-      auto & bb = subtree->blackboard;
-      bb->set("node", node_);
-      bb->set<std::chrono::milliseconds>("server_timeout", std::chrono::milliseconds(20));
-      bb->set<std::chrono::milliseconds>("bt_loop_duration", std::chrono::milliseconds(10));
-      bb->set<std::chrono::milliseconds>("wait_for_service_timeout",
-               std::chrono::milliseconds(1000));
-    }
-
     return true;
   }
 

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -116,7 +116,6 @@ public:
                           kXmlExtension.size(), kXmlExtension) != 0);
 
     std::set<std::string> registered_ids;
-    std::vector<std::pair<std::string, std::string>> files_to_register;
 
     if (!is_bt_id) {
       std::string main_file = file_or_id;
@@ -126,7 +125,8 @@ public:
         std::cerr << "Failed to extract ID from " << main_file << "\n";
         return false;
       }
-      files_to_register.emplace_back(main_id, main_file);
+      std::cout << "Registering Tree from File: " << main_file << "\n";
+      factory_.registerBehaviorTreeFromFile(main_file);
       registered_ids.insert(main_id);
 
       for (const auto & directory : search_directories) {
@@ -144,7 +144,8 @@ public:
                         << " (duplicate ID " << id << ")\n";
               continue;
             }
-            files_to_register.emplace_back(id, entry.path().string());
+            std::cout << "Registering Tree from File: " << entry.path().string() << "\n";
+            factory_.registerBehaviorTreeFromFile(entry.path().string());
             registered_ids.insert(id);
           }
         } catch (const std::exception & e) {
@@ -153,10 +154,6 @@ public:
         }
       }
 
-      for (const auto & [id, path] : files_to_register) {
-        std::cout << "Registering Tree from File: " << path << "\n";
-        factory_.registerBehaviorTreeFromFile(path);
-      }
 
       blackboard = setBlackboardVariables();
       try {
@@ -183,7 +180,8 @@ public:
         std::cerr << "Could not find file for BT ID: " << file_or_id << "\n";
         return false;
       }
-      files_to_register.emplace_back(file_or_id, main_file);
+      std::cout << "Registering Tree from File: " << main_file << "\n";
+      factory_.registerBehaviorTreeFromFile(main_file);
       registered_ids.insert(file_or_id);
 
       for (const auto & directory : search_directories) {
@@ -201,7 +199,8 @@ public:
                         << " (duplicate ID " << id << ")\n";
               continue;
             }
-            files_to_register.emplace_back(id, entry.path().string());
+            std::cout << "Registering Tree from File: " << entry.path().string() << "\n";
+            factory_.registerBehaviorTreeFromFile(entry.path().string());
             registered_ids.insert(id);
           }
         } catch (const std::exception & e) {
@@ -210,10 +209,6 @@ public:
         }
       }
 
-      for (const auto & [id, path] : files_to_register) {
-        std::cout << "Registering Tree from File: " << path << "\n";
-        factory_.registerBehaviorTreeFromFile(path);
-      }
       blackboard = setBlackboardVariables();
       try {
         tree = factory_.createTree(file_or_id, blackboard);

--- a/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
+++ b/nav2_system_tests/src/behavior_tree/test_behavior_tree_node.cpp
@@ -113,90 +113,115 @@ public:
     const std::string kXmlExtension = ".xml";
     const bool is_bt_id = (file_or_id.length() < kXmlExtension.size()) ||
       (file_or_id.compare(file_or_id.length() - kXmlExtension.size(),
-                            kXmlExtension.size(), kXmlExtension) != 0);
+                          kXmlExtension.size(), kXmlExtension) != 0);
 
-    std::unordered_map<std::string, std::string> id_to_file;
-    std::unordered_set<std::string> duplicate_ids;
+    std::set<std::string> registered_ids;
+    std::vector<std::pair<std::string, std::string>> files_to_register;
 
-    for (const auto & directory : search_directories) {
-      try {
-        for (const auto & entry : fs::directory_iterator(directory)) {
-          if (entry.path().extension() != ".xml") {continue;}
+    if (!is_bt_id) {
+      std::string main_file = file_or_id;
+      std::string main_id = bt_engine_->extractBehaviorTreeID(main_file);
 
-          auto id = bt_engine_->extractBehaviorTreeID(entry.path().string());
-          if (id.empty()) {
-            std::cerr << "Skipping BT file " << entry.path() << " (missing ID)\n";
-            continue;
-          }
-
-          if (id_to_file.count(id)) {
-            duplicate_ids.insert(id);
-            std::cerr         << "Duplicate BT ID detected: " << id
-                              << " in files [" << id_to_file[id]
-                              << ", " << entry.path() << "]\n";
-          } else {
-            id_to_file[id] = entry.path().string();
-          }
-        }
-      } catch (const std::exception & e) {
-        std::cerr << "Exception reading behavior tree directory: " << std::string(e.what());
+      if (main_id.empty()) {
+        std::cerr << "Failed to extract ID from " << main_file << "\n";
         return false;
       }
-    }
+      files_to_register.emplace_back(main_id, main_file);
+      registered_ids.insert(main_id);
 
-    // Create and populate the blackboard
-    blackboard = setBlackboardVariables();
-
-    // Build the tree from the ID (resolved from <root> or <BehaviorTree ID>)
-    try {
-      std::string main_file;
-      std::string main_id;
-
-      if (!is_bt_id) {
-        main_file = file_or_id;
-        main_id = bt_engine_->extractBehaviorTreeID(main_file);
-
-        if (main_id.empty()) {
-          std::cerr << "Failed to extract ID from " << main_file << "\n";
+      for (const auto & directory : search_directories) {
+        try {
+          for (const auto & entry : fs::directory_iterator(directory)) {
+            if (entry.path().extension() != ".xml") {continue;}
+            if (entry.path().string() == main_file) {continue;}
+            auto id = bt_engine_->extractBehaviorTreeID(entry.path().string());
+            if (id.empty()) {
+              std::cerr << "Skipping BT file " << entry.path() << " (missing ID)\n";
+              continue;
+            }
+            if (registered_ids.count(id)) {
+              std::cerr << "Skipping conflicting BT file " << entry.path()
+                        << " (duplicate ID " << id << ")\n";
+              continue;
+            }
+            files_to_register.emplace_back(id, entry.path().string());
+            registered_ids.insert(id);
+          }
+        } catch (const std::exception & e) {
+          std::cerr << "Exception reading behavior tree directory: " << std::string(e.what());
           return false;
         }
+      }
 
-            // Register all trees, skipping duplicates that conflict with main tree
-        for (const auto & [id, path] : id_to_file) {
-          if (id == main_id && path != main_file) {
-            std::cerr         << "Skipping conflicting BT file " << path
-                              << " (duplicate ID " << id << ")\n";
-            continue;
-          }
-          std::cout << "Registering Tree from File: " << path << "\n";
-          factory_.registerBehaviorTreeFromFile(path);
-        }
+      for (const auto & [id, path] : files_to_register) {
+        std::cout << "Registering Tree from File: " << path << "\n";
+        factory_.registerBehaviorTreeFromFile(path);
+      }
 
-        std::cout << "Registering main BT file explicitly: " << main_file << "\n";
-        factory_.registerBehaviorTreeFromFile(main_file);
-
+      blackboard = setBlackboardVariables();
+      try {
         tree = factory_.createTree(main_id, blackboard);
         std::cout << "Created BT from ID: " << main_id << "\n";
-
-      } else {   // Load by ID
-        if (duplicate_ids.count(file_or_id)) {
-          std::cerr       << "Conflicting BT ID '" << file_or_id
-                          << "' found in multiple files. Loading may be ambiguous. "
-            "Consider using unique IDs for each BT file.\n";
-        }
-
-        for (const auto & [id, path] : id_to_file) {
-          if (path.empty()) {continue;}
-          std::cout << "Registering Tree from File: " << path << "\n";
-          factory_.registerBehaviorTreeFromFile(path);
-        }
-
-        tree = factory_.createTree(file_or_id, blackboard);
-        std::cout << "Creating tree from ID: " << file_or_id << "\n";
+      } catch (BT::RuntimeError & exp) {
+        std::cerr << "Failed to create BT " << main_id << ": " << exp.what() << "\n";
+        return false;
       }
-    } catch (BT::RuntimeError & exp) {
-      std::cerr << "Failed to create BT " << file_or_id << ": " << exp.what() << "\n";
-      return false;
+    } else {
+      std::string main_file;
+      for (const auto & directory : search_directories) {
+        for (const auto & entry : fs::directory_iterator(directory)) {
+          if (entry.path().extension() != ".xml") {continue;}
+          auto id = bt_engine_->extractBehaviorTreeID(entry.path().string());
+          if (id == file_or_id) {
+            main_file = entry.path().string();
+            break;
+          }
+        }
+        if (!main_file.empty()) {break;}
+      }
+      if (main_file.empty()) {
+        std::cerr << "Could not find file for BT ID: " << file_or_id << "\n";
+        return false;
+      }
+      files_to_register.emplace_back(file_or_id, main_file);
+      registered_ids.insert(file_or_id);
+
+      for (const auto & directory : search_directories) {
+        try {
+          for (const auto & entry : fs::directory_iterator(directory)) {
+            if (entry.path().extension() != ".xml") {continue;}
+            if (entry.path().string() == main_file) {continue;}
+            auto id = bt_engine_->extractBehaviorTreeID(entry.path().string());
+            if (id.empty()) {
+              std::cerr << "Skipping BT file " << entry.path() << " (missing ID)\n";
+              continue;
+            }
+            if (registered_ids.count(id)) {
+              std::cerr << "Skipping conflicting BT file " << entry.path()
+                        << " (duplicate ID " << id << ")\n";
+              continue;
+            }
+            files_to_register.emplace_back(id, entry.path().string());
+            registered_ids.insert(id);
+          }
+        } catch (const std::exception & e) {
+          std::cerr << "Exception reading behavior tree directory: " << std::string(e.what());
+          return false;
+        }
+      }
+
+      for (const auto & [id, path] : files_to_register) {
+        std::cout << "Registering Tree from File: " << path << "\n";
+        factory_.registerBehaviorTreeFromFile(path);
+      }
+      blackboard = setBlackboardVariables();
+      try {
+        tree = factory_.createTree(file_or_id, blackboard);
+        std::cout << "Created BT from ID: " << file_or_id << "\n";
+      } catch (BT::RuntimeError & exp) {
+        std::cerr << "Failed to create BT " << file_or_id << ": " << exp.what() << "\n";
+        return false;
+      }
     }
 
     return true;
@@ -323,6 +348,7 @@ TEST_F(BehaviorTreeTestFixture, TestWrongBTFormatXML)
   write_file(main_file,
     "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
     "<root BTCPP_format=\"4\" main_tree_to_execute=\"MainTree\">\n"
+    "  <include path=\"/tmp/valid_subtree.xml\">\n"
     "  <BehaviorTree ID=\"MainTree\">\n"
     "    <Subtree ID=\"NoopTree\"/>\n"
     "  </BehaviorTree>\n"
@@ -422,7 +448,6 @@ TEST_F(BehaviorTreeTestFixture, TestDuplicateIDsWithFileSpecified) {
   std::string tmp_dir = "/tmp/bt_test_dup_file";
   std::filesystem::create_directories(tmp_dir);
 
-  // Two files with same ID
   std::string dup1_file = tmp_dir + "/dup1.xml";
   std::string dup2_file = tmp_dir + "/dup2.xml";
   std::string dup_bt_content =
@@ -435,31 +460,32 @@ TEST_F(BehaviorTreeTestFixture, TestDuplicateIDsWithFileSpecified) {
   write_file(dup1_file, dup_bt_content);
   write_file(dup2_file, dup_bt_content);
 
-  // Redirect cout/cerr
   std::stringstream captured_output;
   std::streambuf * old_cout = std::cout.rdbuf();
   std::streambuf * old_cerr = std::cerr.rdbuf();
   std::cout.rdbuf(captured_output.rdbuf());
   std::cerr.rdbuf(captured_output.rdbuf());
 
-  // Specify the file to use
-  bool result = bt_handler->loadBehaviorTree(dup2_file, {tmp_dir});
+  bool result = bt_handler->loadBehaviorTree(dup1_file, {tmp_dir});
 
-  // Restore streams
   std::cout.rdbuf(old_cout);
   std::cerr.rdbuf(old_cerr);
 
   std::string log_output = captured_output.str();
+  std::cout << "Captured:\n" << log_output << std::endl;
+
   EXPECT_TRUE(result);
 
-  // Check that duplicate warning appeared
-  EXPECT_NE(log_output.find("Duplicate BT ID detected: DuplicateTree"), std::string::npos);
+  bool found_conflict =
+    log_output.find("Skipping conflicting BT file \"" + dup2_file +
+      "\" (duplicate ID DuplicateTree)") != std::string::npos;
+  EXPECT_TRUE(found_conflict);
 
-  // Check that the specified file was registered explicitly
-  EXPECT_NE(log_output.find("Registering main BT file explicitly: " + dup2_file),
-      std::string::npos);
+  EXPECT_NE(log_output.find("Registering Tree from File"), std::string::npos);
+  EXPECT_NE(log_output.find("Skipping conflicting BT file"), std::string::npos)
+      << "Should warn about duplicate ID";
+  EXPECT_NE(log_output.find("Created BT from ID: DuplicateTree"), std::string::npos);
 
-  // Cleanup
   std::filesystem::remove_all(tmp_dir);
 }
 
@@ -500,19 +526,16 @@ TEST_F(BehaviorTreeTestFixture, TestAllUniqueIDsWithFileSpecified) {
   std::cout.rdbuf(captured_output.rdbuf());
   std::cerr.rdbuf(captured_output.rdbuf());
 
-  // Load by file name
   bool result = bt_handler->loadBehaviorTree(file1, {tmp_dir});
 
-  // Restore streams
   std::cout.rdbuf(old_cout);
   std::cerr.rdbuf(old_cerr);
 
   std::string log_output = captured_output.str();
   EXPECT_TRUE(result);
 
-  // All BTs should be registered
   EXPECT_NE(log_output.find("Registering Tree from File: " + file2), std::string::npos);
-  EXPECT_NE(log_output.find("Registering main BT file explicitly: " + file1), std::string::npos);
+  EXPECT_NE(log_output.find("Registering Tree from File: " + file1), std::string::npos);
 
   std::filesystem::remove_all(tmp_dir);
 }
@@ -547,109 +570,85 @@ TEST_F(BehaviorTreeTestFixture, TestAllUniqueIDsWithIDSpecified) {
   write_file(file1, bt_content1);
   write_file(file2, bt_content2);
 
-  // Redirect streams
   std::stringstream captured_output;
   std::streambuf * old_cout = std::cout.rdbuf();
   std::streambuf * old_cerr = std::cerr.rdbuf();
   std::cout.rdbuf(captured_output.rdbuf());
   std::cerr.rdbuf(captured_output.rdbuf());
 
-  // Load by BT ID
   bool result = bt_handler->loadBehaviorTree("Tree1", {tmp_dir});
 
-  // Restore streams
   std::cout.rdbuf(old_cout);
   std::cerr.rdbuf(old_cerr);
 
   std::string log_output = captured_output.str();
   EXPECT_TRUE(result);
 
-  // All BTs should be registered (subtree feature works)
   EXPECT_NE(log_output.find("Registering Tree from File: " + file2), std::string::npos);
-  EXPECT_NE(log_output.find("Creating tree from ID: Tree1"), std::string::npos);
+  EXPECT_NE(log_output.find("Created BT from ID: Tree1"), std::string::npos);
 
   std::filesystem::remove_all(tmp_dir);
 }
 
-// TEST_F(BehaviorTreeTestFixture, TestLoadBehaviorTreeMissingAndDuplicateIDs)
-// {
-// auto write_file = [](const std::string & path, const std::string & content) {
-//     std::ofstream ofs(path);
-//     ofs << content;
-//   };
+TEST_F(BehaviorTreeTestFixture, TestDuplicateIDsWithIDSpecified) {
+  auto write_file = [](const std::string & path, const std::string & content) {
+      std::ofstream ofs(path);
+      ofs << content;
+    };
+  std::string tmp_dir = "/tmp/bt_test_dup_id";
+  std::filesystem::create_directories(tmp_dir);
 
-//   std::string tmp_dir = "/tmp/bt_test_dir";
-//   std::filesystem::create_directories(tmp_dir);
+  std::string dup1_file = tmp_dir + "/dup1.xml";
+  std::string dup2_file = tmp_dir + "/dup2.xml";
+  std::string dup_bt_content =
+    "<?xml version=\"1.0\"?>\n"
+    "<root BTCPP_format=\"4\">\n"
+    "  <BehaviorTree ID=\"DuplicateTree\">\n"
+    "    <AlwaysSuccess />\n"
+    "  </BehaviorTree>\n"
+    "</root>\n";
+  write_file(dup1_file, dup_bt_content);
+  write_file(dup2_file, dup_bt_content);
 
-//   // 1. File with missing ID (should be skipped)
-//   std::string missing_id_file = tmp_dir + "/missing_id.xml";
-//   write_file(missing_id_file,
-//     "<?xml version=\"1.0\"?>\n"
-//     "<root BTCPP_format=\"4\">\n"
-//     "  <BehaviorTree>\n"
-//     "    <AlwaysSuccess />\n"
-//     "  </BehaviorTree>\n"
-//     "</root>\n");
+  std::stringstream captured_output;
+  std::streambuf * old_cout = std::cout.rdbuf();
+  std::streambuf * old_cerr = std::cerr.rdbuf();
+  std::cout.rdbuf(captured_output.rdbuf());
+  std::cerr.rdbuf(captured_output.rdbuf());
 
-//   // 2. Two files with the same ID (should trigger duplicate warning)
-//   std::string dup1_file = tmp_dir + "/dup1.xml";
-//   std::string dup2_file = tmp_dir + "/dup2.xml";
-//   std::string dup_bt_content =
-//     "<?xml version=\"1.0\"?>\n"
-//     "<root BTCPP_format=\"4\">\n"
-//     "  <BehaviorTree ID=\"DuplicateTree\">\n"
-//     "    <AlwaysSuccess />\n"
-//     "  </BehaviorTree>\n"
-//     "</root>\n";
-//   write_file(dup1_file, dup_bt_content);
-//   write_file(dup2_file, dup_bt_content);
+  bool result = bt_handler->loadBehaviorTree("DuplicateTree", {tmp_dir});
 
-//   // Redirect cout and cerr to a stringstream
-//   std::stringstream captured_output;
-//   std::streambuf * old_cout_buf = std::cout.rdbuf();
-//   std::streambuf * old_cerr_buf = std::cerr.rdbuf();
+  std::cout.rdbuf(old_cout);
+  std::cerr.rdbuf(old_cerr);
 
-//   std::cout.rdbuf(captured_output.rdbuf());
-//   std::cerr.rdbuf(captured_output.rdbuf());
+  std::string log_output = captured_output.str();
+  std::cout << "Captured:\n" << log_output << std::endl;
 
-//   std::vector<std::string> search_dirs = {tmp_dir};
-//   bool result = bt_handler->loadBehaviorTree("DuplicateTree", search_dirs);
+  EXPECT_TRUE(result) << "Tree should still load despite duplicate IDs";
 
-//   // Restore cout and cerr
-//   std::cout.rdbuf(old_cout_buf);
-//   std::cerr.rdbuf(old_cerr_buf);
+  EXPECT_NE(log_output.find("Registering Tree from File"), std::string::npos)
+      << "Should have registered at least one BT file";
+  EXPECT_NE(log_output.find("Skipping conflicting BT file"), std::string::npos)
+      << "Should warn about duplicate IDs";
+  EXPECT_NE(log_output.find("Created BT from ID: DuplicateTree"), std::string::npos)
+      << "Should have created BT from the given ID";
 
-//   // Check the captured output for the expected log messages
-//   std::string log_output = captured_output.str();
+bool registered_dup1 =
+    log_output.find("Registering Tree from File: " + dup1_file) != std::string::npos;
+bool registered_dup2 =
+    log_output.find("Registering Tree from File: " + dup2_file) != std::string::npos;
 
-//   // Assert that the function returned true
-//   EXPECT_TRUE(result);
+EXPECT_TRUE(registered_dup1 || registered_dup2)
+    << "At least one duplicate file should have been registered";
+EXPECT_FALSE(registered_dup1 && registered_dup2)
+    << "Only one of the duplicate files should be registered as the main tree";
+EXPECT_NE(log_output.find("Skipping conflicting BT file"), std::string::npos);
+EXPECT_NE(log_output.find("Created BT from ID: DuplicateTree"), std::string::npos);
 
-//   // Assert that the error log for the missing ID was found
-//   EXPECT_NE(log_output.find("[behavior_tree_handler]: Skipping BT file " + missing_id_file +
-//       " (missing ID)"), std::string::npos);
 
-//   // Assert that the warning log for the duplicate ID was found
-//   EXPECT_NE(
-//     log_output.find(
-//       "Warning: Duplicate BT IDs found. Make sure to have all BT IDs unique! "
-//       "ID: DuplicateTree File: "), std::string::npos);
+  std::filesystem::remove_all(tmp_dir);
+}
 
-//   // Cleanup
-//   std::filesystem::remove_all(tmp_dir);
-// }
-
-// TEST_F(BehaviorTreeTestFixture, TestLoadByIdInsteadOfFile)
-// {
-//   const auto root_dir = std::filesystem::path(
-//     ament_index_cpp::get_package_share_directory("nav2_bt_navigator")
-//     ) / "behavior_trees";
-//   std::vector<std::string> search_directories = {root_dir.string()};
-
-//   // Load by BT ID instead of file
-//   EXPECT_TRUE(bt_handler->loadBehaviorTree("NavigateToPoseWReplanningAndRecovery",
-//       search_directories));
-// }
 
 /**
  * Test scenario:


### PR DESCRIPTION
<!-- Please fill out the following pull request template for non-trivial changes to help us process your PR faster and more efficiently.-->

---

## Basic Info

| Info | Please fill out this column |
| ------ | ----------- |
| Ticket(s) this addresses   | (add tickets here #1) |
| Primary OS tested on | (Ubuntu, MacOS, Windows) |
| Robotic platform tested on | (Steve's Robot, gazebo simulation of Tally, hardware turtlebot) |
| Does this PR contain AI generated software? | (No; Yes and it is marked inline in the code) |
| Was this PR description generated by AI software? | Out of respect for maintainers, AI for human-to-human communications are banned |

---

## Description of contribution in a few bullet points

<!--
* I added this neat new feature
* Also fixed a typo in a parameter name in nav2_costmap_2d
-->

## Description of documentation updates required from your changes

<!--
* Added new parameter, so need to add that to default configs and documentation page
* I added some capabilities, need to document them
-->

## Description of how this change was tested

<!--
* I wrote unit tests that cover 90%+ of changes and extensively tested on my physical robot platform in production for 1 week
* I wrote unit tests and tested in simulation for 10 minutes
* Performed linting validation using pre-commit run --all or colcon test
-->

---

## Future work that may be required in bullet points

<!--
* I think there might be some optimizations to be made from STL vector
* I see a lot of redundancy in this package, we might want to add a function `bool XYZ()` to reduce clutter
* I tested on a differential drive robot, but there might be issues turning near corners on an omnidirectional platform
-->

#### For Maintainers: <!-- DO NOT EDIT OR REMOVE -->
- [ ] Check that any new parameters added are updated in docs.nav2.org
- [ ] Check that any significant change is added to the migration guide
- [ ] Check that any new features **OR** changes to existing behaviors are reflected in the tuning guide
- [ ] Check that any new functions have Doxygen added
- [ ] Check that any new features have test coverage
- [ ] Check that any new plugins is added to the plugins page
- [ ] If BT Node, Additionally: add to BT's XML index of nodes for groot, BT package's readme table, and BT library lists
- [ ] Should this be backported to current distributions? If so, tag with `backport-*`.
